### PR TITLE
Fix Python 3 compatibility issues

### DIFF
--- a/privacy/analysis/rdp_accountant.py
+++ b/privacy/analysis/rdp_accountant.py
@@ -46,6 +46,11 @@ import sys
 import numpy as np
 from scipy import special
 
+try:
+  long
+except NameError:
+  long = int
+
 ########################
 # LOG-SPACE ARITHMETIC #
 ########################

--- a/privacy/optimizers/dp_optimizer_test.py
+++ b/privacy/optimizers/dp_optimizer_test.py
@@ -24,6 +24,11 @@ import tensorflow as tf
 
 from privacy.optimizers import dp_optimizer
 
+try:
+    xrange
+except NameError:
+    xrange = range
+
 
 def loss(val0, val1):
   """Loss function that is minimized at the mean of the input points."""

--- a/privacy/optimizers/gaussian_query_test.py
+++ b/privacy/optimizers/gaussian_query_test.py
@@ -24,6 +24,11 @@ import tensorflow as tf
 
 from privacy.optimizers import gaussian_query
 
+try:
+    xrange
+except NameError:
+    xrange = range
+
 
 def _run_query(query, records):
   """Executes query on the given set of records as a single sample.

--- a/privacy/optimizers/nested_query_test.py
+++ b/privacy/optimizers/nested_query_test.py
@@ -30,6 +30,11 @@ nest = tf.contrib.framework.nest
 
 _basic_query = gaussian_query.GaussianSumQuery(1.0, 0.0)
 
+try:
+    xrange
+except NameError:
+    xrange = range
+
 
 def _run_query(query, records):
   """Executes query on the given set of records as a single sample.


### PR DESCRIPTION
__long__ and __xrange()__ were removed in Python 3.

[flake8](http://flake8.pycqa.org) testing of https://github.com/tensorflow/privacy on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./privacy/optimizers/nested_query_test.py:143:16: F821 undefined name 'xrange'
      for _ in xrange(1000):
               ^
./privacy/optimizers/gaussian_query_test.py:83:16: F821 undefined name 'xrange'
      for _ in xrange(1000):
               ^
./privacy/optimizers/gaussian_query_test.py:112:16: F821 undefined name 'xrange'
      for _ in xrange(1000):
               ^
./privacy/optimizers/dp_optimizer_test.py:115:16: F821 undefined name 'xrange'
      for _ in xrange(1000):
               ^
./privacy/analysis/rdp_accountant.py:89:34: F821 undefined name 'long'
  assert isinstance(alpha, (int, long))
                                 ^
5     F821 undefined name 'long'
5
```