### PR TITLE
from six.moves import xrange

### DIFF
--- a/privacy/optimizers/gaussian_query_test.py
+++ b/privacy/optimizers/gaussian_query_test.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 from absl.testing import parameterized
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 from privacy.optimizers import gaussian_query

--- a/research/pate_2018/ICLR2018/rdp_bucketized.py
+++ b/research/pate_2018/ICLR2018/rdp_bucketized.py
@@ -36,17 +36,16 @@ import math
 import os
 import sys
 
-from six.moves import xrange
-
 sys.path.append('..')  # Main modules reside in the parent directory.
 
 from absl import app
 from absl import flags
+import core as pate
 import matplotlib
 matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt  # pylint: disable=g-import-not-at-top
 import numpy as np
-import core as pate
+from six.moves import xrange
 
 plt.style.use('ggplot')
 

--- a/research/pate_2018/ICLR2018/rdp_bucketized.py
+++ b/research/pate_2018/ICLR2018/rdp_bucketized.py
@@ -36,6 +36,8 @@ import math
 import os
 import sys
 
+from six.moves import xrange
+
 sys.path.append('..')  # Main modules reside in the parent directory.
 
 from absl import app


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of a reworked version of __range()__.

[flake8](http://flake8.pycqa.org) testing of https://github.com/tensorflow/privacy on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./privacy/optimizers/gaussian_query_test.py:65:16: F821 undefined name 'xrange'
      for _ in xrange(1000):
               ^
./research/pate_2018/ICLR2018/rdp_bucketized.py:79:12: F821 undefined name 'xrange'
  for i in xrange(n):
           ^
./research/pate_2018/ICLR2018/rdp_bucketized.py:106:12: F821 undefined name 'xrange'
  for i in xrange(n):
           ^
./research/pate_2018/ICLR2018/rdp_bucketized.py:139:12: F821 undefined name 'xrange'
  for i in xrange(n):
           ^
4     F821 undefined name 'xrange'
4
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree