### PR TITLE
Fix nest import in quantile adaptive query

### DIFF
--- a/privacy/dp_query/quantile_adaptive_clip_sum_query.py
+++ b/privacy/dp_query/quantile_adaptive_clip_sum_query.py
@@ -26,6 +26,7 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+from distutils.version import LooseVersion
 
 import tensorflow as tf
 
@@ -33,7 +34,10 @@ from privacy.dp_query import dp_query
 from privacy.dp_query import gaussian_query
 from privacy.dp_query import normalized_query
 
-nest = tf.contrib.framework.nest
+if LooseVersion(tf.__version__) < LooseVersion('2.0.0'):
+  nest = tf.contrib.framework.nest
+else:
+  nest = tf.nest
 
 
 class QuantileAdaptiveClipSumQuery(dp_query.DPQuery):


### PR DESCRIPTION
`quantile_adaptive_clip_sum_query.py` was expecting tf.contrib.nest, but in TF 2.0 this causes an ImportError.  This PR determines the nest module based on the version of TF, as in other files.