### PR TITLE
Rdp for subsampled gaussian mechanism under the sampling without replacement scheme

### DIFF
--- a/privacy/analysis/test_rdp_calculations.py
+++ b/privacy/analysis/test_rdp_calculations.py
@@ -1,0 +1,22 @@
+from rdp_accountant import compute_rdp, compute_rdp_sample_without_replacement
+import numpy as np
+
+
+#  A simple test script to demonstrate the calculated RDP
+
+q= 0.01
+noise_multiplier = 2
+steps = 10
+orders = np.linspace(2,100,99)
+
+results1 = compute_rdp(q, noise_multiplier, steps,orders)
+
+results2 = compute_rdp_sample_without_replacement(q, noise_multiplier, steps, orders)
+
+
+import matplotlib.pyplot as plt
+
+plt.loglog(orders, results1,label='Poisson sampling')
+plt.loglog(orders, results2,label='Sample without replacement')
+plt.legend()
+plt.show()


### PR DESCRIPTION
1. Function `compute_rdp_sample_without_replacement` implements Theorem 9 of Wang, Balle, Kasiviswanathan. "[Subsampled Renyi Differential Privacy and Analytical Moments Accountant](https://arxiv.org/pdf/1808.00087.pdf)." AISTATS'2019. 

2. Added a test script.

3. Added a reference to why `compute_rdp` is correctly calculating the RDP for subsampled Gaussian mechanism under the Poisson sampling scheme (independently include a data point with probability q).  At least for integer order...