### PR TITLE
Undefined name: xrange() was removed in Python 3

### DIFF
--- a/privacy/dp_query/quantile_adaptive_clip_sum_query_test.py
+++ b/privacy/dp_query/quantile_adaptive_clip_sum_query_test.py
@@ -77,7 +77,7 @@ class QuantileAdaptiveClipSumQueryTest(tf.test.TestCase):
         expected_num_records=2.0)
 
     noised_sums = []
-    for _ in xrange(1000):
+    for _ in range(1000):
       query_result, _ = test_utils.run_query(query, [record1, record2])
       noised_sums.append(query_result.numpy())
 


### PR DESCRIPTION
Eleven years ago __xrange()__ was removed in Python 3 in favor of __range()__.