### PR TITLE
Fix: max_auc for summary without slices

### DIFF
--- a/tensorflow_privacy/privacy/privacy_tests/membership_inference_attack/data_structures.py
+++ b/tensorflow_privacy/privacy/privacy_tests/membership_inference_attack/data_structures.py
@@ -678,7 +678,7 @@ class AttackResults:
     summary = []
 
     # Summary over all slices
-    max_auc_result_all = self.get_result_with_max_attacker_advantage()
+    max_auc_result_all = self.results.get_result_with_max_auc()
     summary.append('Best-performing attacks over all slices')
     summary.append(
         '  %s (with %d training and %d test examples) achieved an AUC of %.2f on slice %s'


### PR DESCRIPTION
Before: summary shows the AUC of the result with the max attacker advantage
Expected and now: summary shows the AUC of the result with max AUC