### PR TITLE
Extremely high epsilon in MNIST Keras tutorials

### DIFF
--- a/tutorials/mnist_dpsgd_tutorial_keras.py
+++ b/tutorials/mnist_dpsgd_tutorial_keras.py
@@ -28,7 +28,7 @@ flags.DEFINE_boolean(
     'dpsgd', True, 'If True, train with DP-SGD. If False, '
     'train with vanilla SGD.')
 flags.DEFINE_float('learning_rate', 0.15, 'Learning rate for training')
-flags.DEFINE_float('noise_multiplier', 0.1,
+flags.DEFINE_float('noise_multiplier', 1.1,
                    'Ratio of the standard deviation to the clipping norm')
 flags.DEFINE_float('l2_norm_clip', 1.0, 'Clipping norm')
 flags.DEFINE_integer('batch_size', 250, 'Batch size')

--- a/tutorials/mnist_dpsgd_tutorial_keras_model.py
+++ b/tutorials/mnist_dpsgd_tutorial_keras_model.py
@@ -27,7 +27,7 @@ flags.DEFINE_boolean(
     'dpsgd', True, 'If True, train with DP-SGD. If False, '
     'train with vanilla SGD.')
 flags.DEFINE_float('learning_rate', 0.15, 'Learning rate for training')
-flags.DEFINE_float('noise_multiplier', 0.1,
+flags.DEFINE_float('noise_multiplier', 1.1,
                    'Ratio of the standard deviation to the clipping norm')
 flags.DEFINE_float('l2_norm_clip', 1.0, 'Clipping norm')
 flags.DEFINE_integer('batch_size', 250, 'Batch size')


### PR DESCRIPTION
The `noise_multiplier` in the MNIST Keras tutorials is extremely low (0.1). This results in an epsilon of 66416.55 after  60 epochs of training. Looks like this is a typo introduced by this commit: [tutorials/mnist_dpsgd_tutorial_keras.py](https://github.com/tensorflow/privacy/commit/3240a71965c2354bc07c6660d1af5f35ca75fe0a#diff-1bff04b30ab9d8d335d7e2a11b7ba27dca6bf64829e7847db6eea251fd813d03R35).